### PR TITLE
Fix incorrect duration for small number

### DIFF
--- a/Objective-C/FlickerNumber/Classes/UILabel+FlickerNumber.m
+++ b/Objective-C/FlickerNumber/Classes/UILabel+FlickerNumber.m
@@ -189,9 +189,6 @@ NS_ASSUME_NONNULL_BEGIN
     
     [userInfo setObject:@(multiple) forKey:DDMultipleKey];
     [userInfo setObject:@(endNumber) forKey:DDEndNumberKey];
-    if ((endNumber * DDFrequency)/duration < 1) {
-        duration = duration * 0.3;
-    }
     [userInfo setObject:@((endNumber * DDFrequency)/duration) forKey:DDRangeIntegerKey];
     
     if(attrs)

--- a/Swift/FlickerNumber-Swift/UILabel+FlickerNumber.swift
+++ b/Swift/FlickerNumber-Swift/UILabel+FlickerNumber.swift
@@ -200,7 +200,7 @@ extension UILabel {
         }
         
         //limit duration is positive number and it is larger than 0.3
-        var durationTime : TimeInterval = Swift.max(fabs(duration), 0.3)
+        let durationTime : TimeInterval = Swift.max(fabs(duration), 0.3)
         
         self.fn_timer?.invalidate()
         
@@ -235,9 +235,6 @@ extension UILabel {
         userDict.setValue(multiple, forKey: multipleName)
         userDict.setValue(NSNumber(value: endNumber), forKey: endNumberName)
         
-        if (Double(endNumber) * frequency)/durationTime < 1.0 {
-            durationTime = durationTime * 0.3
-        }
         let rangeNumber = (Double(endNumber) * frequency)/durationTime
         userDict.setValue(NSNumber(value: rangeNumber), forKey: rangeIntegerName)
         


### PR DESCRIPTION
Fix #5.

You can reproduce the issue for instance by setting `number` to something small like `2` and duration to `10`: you'll notice that it will last only three seconds instead of ten seconds.